### PR TITLE
Latest react native compatibility

### DIFF
--- a/platforms/ios/snowball.c
+++ b/platforms/ios/snowball.c
@@ -1,4 +1,4 @@
-#include <libstemmer.h>
+#include "libstemmer.h"
 #include <sqlite3ext.h>
 #include <string.h>
 

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,9 +1,6 @@
 module.exports = {
 	dependency: {
 		platforms: {
-			ios: {
-				project: './platforms/ios/SQLite.xcodeproj'
-			},
 			android: {
 				sourceDir: './platforms/android'
 			}


### PR DESCRIPTION
This PR fixes two issues that I encountered when upgrading CoreP app to RN 0.71.3:
- Fix not able to build CoreP app on iOS with RN 0.71.3 
<img width="874" alt="Screenshot 2023-02-23 at 11 12 59" src="https://user-images.githubusercontent.com/42188926/222631894-0a03abae-983f-4dba-9819-c200d4b60a19.png">
- Fix React Native bundler warning 
<img width="874" alt="image" src="https://user-images.githubusercontent.com/42188926/222632817-b195facb-40cf-4504-85e7-75d341c47f3c.png">

Testing instructions: 
- Checkout [Upgrade React Native PR](https://github.com/silverorange/emrap-corependium/pull/2208)
- Replace "git+ssh://git@github.com/silverorange/react-native-sqlite-storage.git#search-tokenizers" with "git+ssh://git@github.com/argeoph/react-native-sqlite-storage.git#latest-react-native-compatibility" in package.json
- Run `rm -rf node_modules && yarn && yarn start --reset-cache`
- In a different terminal window run: `cd ios && npx pod install && cd ../ && yarn ios `
- Make sure that CoreP compiles without errors now and that it works as expected